### PR TITLE
Fix bugs when copy data from one bucket-type to another

### DIFF
--- a/src/sumo_store_riak_restor_obj.erl
+++ b/src/sumo_store_riak_restor_obj.erl
@@ -90,7 +90,7 @@ persist(<<>>, Doc, #state{conn = Conn, bucket = Bucket, put_opts = _Opts} = Stat
   end;
 
 %% update object
-persist(OldObj, Doc, #state{conn = Conn,  put_opts = _Opts} = State) ->
+persist(OldObj, Doc, #state{conn = Conn,  put_opts = _Opts, bucket = Bucket} = State) ->
   {IdField, Id} = get_id(Doc),
    JsonDoc = doc_to_json(Doc),
 


### PR DESCRIPTION
Khi copy data từ một bucket-type  sang bucket-type khác thì bị lỗi vẫn update vào bucket-type cũ. Nguyên nhân do khi update thì sumo ignore bucket-type mới => Đã fix